### PR TITLE
Update initramfs_add_modules to include lvm module

### DIFF
--- a/roles/shrink_lv/tasks/main.yaml
+++ b/roles/shrink_lv/tasks/main.yaml
@@ -27,7 +27,7 @@
 
 - name: Create the initramfs and reboot to run the module
   vars:
-    initramfs_add_modules: "shrink_lv"
+    initramfs_add_modules: "shrink_lv lvm"
   ansible.builtin.include_role:
     name: initramfs
 


### PR DESCRIPTION
Testing discovered a scenario in which LVM is in use, but the `lvm` module is not present in the initramfs image. This causes a failure on the host during the reboot phase, since LVM will never get loaded.

The value for `initramfs_add_modules` has been updated to include the `lvm` module explicitly.