### PR TITLE
Add validation that the requested volumes have shrunk 

### DIFF
--- a/roles/shrink_lv/tasks/main.yaml
+++ b/roles/shrink_lv/tasks/main.yaml
@@ -35,3 +35,20 @@
   ansible.builtin.file:
     path: /usr/lib/dracut/modules.d/99shrink_lv
     state: absent
+
+- name: Retrieve mount points
+  ansible.builtin.setup:
+    gather_subset:
+    - "!all"
+    - "!min"
+    - mounts
+
+- name: Assert that the filesystem has shrunk
+  ansible.builtin.assert:
+    # yamllint disable-line rule:line-length
+    that: (ansible_facts.mounts | selectattr('device', 'equalto', item.device) | map(attribute='size_total') | join | int) <= (item.size | ansible.builtin.human_to_bytes)
+    fail_msg: >
+      Logical Volume {{ item.device }} was not shrunk to {{ item.size }} as requested
+    success_msg: >
+      Logical Volume {{ item.device }} has been shrunk to {{ item.size }} as requested.
+  loop: "{{ shrink_lv_devices }}"


### PR DESCRIPTION
Per issue #46, this adds validation that the requested volume(s) have reduced in size. 

There is a difference between the number of bytes being returned from `ansible_facts.mounts` via `size_total` vs. converting a string to bytes using the `ansible.builtin.human_to_bytes` filter.

For example a 60GB volume reports as `63281336320` bytes via `size_total` in facts, whereas converting `60G` to bytes via `ansible.builtin.human_to_bytes` results in `64424509440` bytes:

```
            {
                "block_available": 14645648,
                "block_size": 4096,
                "block_total": 15449545,
                "block_used": 803897,
                "device": "/dev/mapper/test--vg01-test--lv01",
                "fstype": "ext4",
                "inode_available": 3940341,
                "inode_total": 3940352,
                "inode_used": 11,
                "mount": "/lvol/test-lv01",
                "options": "rw,seclabel,relatime,data=ordered",
                "size_available": 59988574208,
                "size_total": 63281336320,
                "uuid": "6a586097-166b-4d56-b68d-40da561a9a52"
            }
```

```
ok: [shrink-lv-test3] => (item={'device': '/dev/mapper/test--vg01-test--lv01', 'size': '60G'}) => {
    "msg": "/dev/mapper/test--vg01-test--lv01 -> 64424509440"
}
```

As a result we resort to checking if the byte size is simply lesser than or equal to the converted value as its always slightly higher.

