### PR TITLE
Make bigboot more idempotent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the LVM Snapshots Collection. All we ask is that contributors please observe the [Ansible Community Guidelines](https://docs.ansible.com/ansible/devel/community/index.html) and follow the [Ansible Collections Contributor Guide](https://docs.ansible.com/ansible/devel/community/contributions_collections.html). We look forward to reviewing your pull request.
 
-Everyone is invited to participate. We welcome first timers as well as experienced open source contributors. If you are unsure how to get started with your contributon, open a [new issue](https://github.com/redhat-cop/infra.lvm_snapshots/issues/new/choose) explaining what you want to do and we'll do our best to help!
+Everyone is invited to participate. We welcome first timers as well as experienced open source contributors. If you are unsure how to get started with your contribution, open a [new issue](https://github.com/redhat-cop/infra.lvm_snapshots/issues/new/choose) explaining what you want to do and we'll do our best to help!

--- a/changelogs/fragments/more_idempotent.yml
+++ b/changelogs/fragments/more_idempotent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- new bigboot_partition_size variable to make bigboot role more idempotent

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.15.0'

--- a/roles/bigboot/README.md
+++ b/roles/bigboot/README.md
@@ -11,7 +11,7 @@ Finally, there is a copy of the [`sfdisk`](https://man7.org/linux/man-pages/man8
 
 > **WARNING!**
 >
-> All blocks of the partition above the boot partition are copied using `sfdisk` during the reboot and this can take serveral minutes or more depending on the size of that partition. The bigboot script periodically outputs progress messages to the system console to make it clear that the system is not in a "hung" state, but these progress messages may not be seen if `rhgb` or `quiet` kernel arguments are set. If the system is reset while the blocks are being copied, the partition will be irrcoverably corrupted. Do not assume the system is hung or force a reset during the bigboot reboot!
+> All blocks of the partition above the boot partition are copied using `sfdisk` during the reboot and this can take several minutes or more depending on the size of that partition. The bigboot script periodically outputs progress messages to the system console to make it clear that the system is not in a "hung" state, but these progress messages may not be seen if `rhgb` or `quiet` kernel arguments are set. If the system is reset while the blocks are being copied, the partition will be irrcoverably corrupted. Do not assume the system is hung or force a reset during the bigboot reboot!
 
 To learn more about how bigboot works, check out this [video](https://people.redhat.com/bmader/bigboot-demo.mp4).
 

--- a/roles/bigboot/README.md
+++ b/roles/bigboot/README.md
@@ -9,15 +9,27 @@ The role is designed to support the automation of RHEL in-place upgrades, but ca
 The role contains the shell scripts to increase the size of the boot partition, as well as the script wrapping it to run as part of the pre-mount step during the boot process.
 Finally, there is a copy of the [`sfdisk`](https://man7.org/linux/man-pages/man8/sfdisk.8.html) binary with version `2.38.1` to ensure the extend script will work regardless of the `util-linux` package installed in the target host.
 
+> **WARNING!**
+>
+> All blocks of the partition above the boot partition are copied using `sfdisk` during the reboot and this can take serveral minutes or more depending on the size of that partition. The bigboot script periodically outputs progress messages to the system console to make it clear that the system is not in a "hung" state, but these progress messages may not be seen if `rhgb` or `quiet` kernel arguments are set. If the system is reset while the blocks are being copied, the partition will be irrcoverably corrupted. Do not assume the system is hung or force a reset during the bigboot reboot!
+
+To learn more about how bigboot works, check out this [video](https://people.redhat.com/bmader/bigboot-demo.mp4).
+
 ## Role Variables
+
+### `bigboot_partition_size` (String)
+
+The variable `bigboot_partition_size` specifies the minimum required size of the boot partition. If the boot partition is already equal to or greater than the given size, the role will end gracefully making no changes. The value can be either in bytes or with optional single letter suffix (1024 bases) using [human_to_bytes](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/human_to_bytes_filter.html) filter plugin.
 
 ### `bigboot_size` (String)
 
-The variable `bigboot_size` specifies by how much the size of the boot partition should be increased. The value can be either in bytes or with optional single letter suffix (1024 bases). See unit options type `iec` of [`numfmt`](https://man7.org/linux/man-pages/man1/numfmt.1.html).
+This variable is deprecated and will be removed in a future release. Use `bigboot_partition_size` instead.
+
+The variable `bigboot_size` specifies by how much the size of the boot partition is to be increased. The value can be either in bytes or with optional single letter suffix (1024 bases) using [human_to_bytes](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/human_to_bytes_filter.html) filter plugin. 
 
 > **Note**
 >
-> The effective `bigboot_size` may be slightly less than the specified value as the role will round down to the nearest multiple of the extent size of the LVM physical volume in the partition above the boot partition.
+> The size increase may be slightly less than the specified value as the role will round down to the nearest multiple of the extent size of the LVM physical volume in the partition above the boot partition.
 
 ## Example of a playbook to run the role
 The following yaml is an example of a playbook that runs the role against a group of hosts named `rhel` and increasing the size of its boot partition by 1G.
@@ -27,7 +39,7 @@ The boot partition is automatically retrieved by the role by identifying the exi
 - name: Extend boot partition playbook
   hosts: all
   vars:
-    bigboot_size: 1G
+    bigboot_partition_size: 1G
   roles:
     - bigboot
 ```

--- a/roles/bigboot/defaults/main.yaml
+++ b/roles/bigboot/defaults/main.yaml
@@ -1,1 +1,2 @@
+bigboot_partition_size:
 bigboot_size:

--- a/roles/bigboot/tasks/get_boot_device_info.yml
+++ b/roles/bigboot/tasks/get_boot_device_info.yml
@@ -17,4 +17,10 @@
     bigboot_boot_device_partition_prefix: "{{ bigboot_boot_partition_name[(bigboot_boot_disk | length) : -1] }}"
     bigboot_boot_partition_number: "{{ bigboot_boot_partition_name[-1] }}"
     bigboot_boot_device_name: "/dev/{{ bigboot_boot_disk }}"
-    bigboot_boot_device_original_size: "{{ bigboot_boot_mount_entry.size_total | int }}"
+    bigboot_boot_fs_original_size: "{{ bigboot_boot_mount_entry.size_total | int }}"
+    bigboot_boot_device_sectors: "{{ ansible_facts.devices[bigboot_boot_disk].partitions[bigboot_boot_partition_name].sectors | int }}"
+    bigboot_boot_device_sectorsize: "{{ ansible_facts.devices[bigboot_boot_disk].partitions[bigboot_boot_partition_name].sectorsize | int }}"
+
+- name: Calculate boot device current size
+  ansible.builtin.set_fact:
+    bigboot_boot_device_bytes: "{{ bigboot_boot_device_sectors | int * bigboot_boot_device_sectorsize | int }}"

--- a/roles/bigboot/tasks/main.yaml
+++ b/roles/bigboot/tasks/main.yaml
@@ -7,11 +7,6 @@
     - mounts
     - devices
 
-- name: Validate bigboot_size is not empty
-  ansible.builtin.assert:
-    that: bigboot_size | length >0
-    fail_msg: "bigboot_size is empty"
-
 - name: Validate initramfs preflight
   ansible.builtin.include_role:
     name: initramfs
@@ -21,46 +16,70 @@
   ansible.builtin.include_tasks:
     file: get_boot_device_info.yml
 
-- name: Copy extend boot dracut module
-  ansible.builtin.copy:
-    src: "{{ item }}"
-    dest: /usr/lib/dracut/modules.d/99extend_boot/
-    mode: "0554"
-  loop:
-  - bigboot.sh
-  - module-setup.sh
-  - sfdisk.static
-
-- name: Resolve and copy the shrink-start script
-  ansible.builtin.template:
-    src: increase-boot-partition.sh.j2
-    dest: /usr/lib/dracut/modules.d/99extend_boot/increase-boot-partition.sh
-    mode: '0554'
-
-- name: Create the initramfs and reboot to run the module
-  vars:
-    initramfs_add_modules: "extend_boot"
-  ansible.builtin.include_role:
-    name: initramfs
-
-- name: Remove dracut extend boot module
-  ansible.builtin.file:
-    path: /usr/lib/dracut/modules.d/99extend_boot
-    state: absent
-
-- name: Retrieve mount points
-  ansible.builtin.setup:
-    gather_subset:
-    - "!all"
-    - "!min"
-    - mounts
-
-- name: Capture boot device new size
+- name: Convert bigboot_partition_size to bytes
   ansible.builtin.set_fact:
-    bigboot_boot_device_new_size: "{{ (ansible_facts.mounts | selectattr('mount', 'equalto', '/boot') | first).size_total | int }}"
+    bigboot_partition_size_bytes: "{{ bigboot_partition_size | ansible.builtin.human_to_bytes }}"
+  when: bigboot_partition_size | default('', true) | length > 0
 
-- name: Validate boot partition new size
-  ansible.builtin.assert:
-    that:
-    - bigboot_boot_device_new_size != bigboot_boot_device_original_size
-    fail_msg: "Boot partition size '{{ bigboot_boot_device_new_size }}' did not change"
+- name: Convert bigboot_size to bytes
+  ansible.builtin.set_fact:
+    bigboot_size_bytes: "{{ bigboot_size | ansible.builtin.human_to_bytes }}"
+  when: bigboot_partition_size_bytes is undefined and bigboot_size | default('', true) | length > 0
+
+- name: Calculate bigboot increase
+  ansible.builtin.set_fact:
+    bigboot_increase_bytes: "{{ bigboot_partition_size_bytes | default(bigboot_boot_device_bytes, true) | int -
+        bigboot_boot_device_bytes | int +
+        bigboot_size_bytes | default('0', true) | int }}"
+
+- name: Do bigboot tasks if increase requested
+  when: bigboot_increase_bytes | int > 0
+  block:
+  - name: Copy extend boot dracut module
+    ansible.builtin.copy:
+      src: "{{ item }}"
+      dest: /usr/lib/dracut/modules.d/99extend_boot/
+      mode: "0554"
+    loop:
+    - bigboot.sh
+    - module-setup.sh
+    - sfdisk.static
+
+  - name: Resolve and copy the shrink-start script
+    ansible.builtin.template:
+      src: increase-boot-partition.sh.j2
+      dest: /usr/lib/dracut/modules.d/99extend_boot/increase-boot-partition.sh
+      mode: '0554'
+
+  - name: Create the initramfs and reboot to run the module
+    vars:
+      initramfs_add_modules: "extend_boot"
+    ansible.builtin.include_role:
+      name: initramfs
+
+  - name: Remove dracut extend boot module
+    ansible.builtin.file:
+      path: /usr/lib/dracut/modules.d/99extend_boot
+      state: absent
+
+  - name: Retrieve mount points
+    ansible.builtin.setup:
+      gather_subset:
+      - "!all"
+      - "!min"
+      - mounts
+
+  - name: Capture boot filesystem new size
+    ansible.builtin.set_fact:
+      bigboot_boot_fs_new_size: "{{ (ansible_facts.mounts | selectattr('mount', 'equalto', '/boot') | first).size_total | int }}"
+
+  - name: Validate boot filesystem new size
+    ansible.builtin.assert:
+      that:
+      - bigboot_boot_fs_new_size != bigboot_boot_fs_original_size
+      fail_msg: "Boot filesystem size '{{ bigboot_boot_fs_new_size }}' did not change"
+
+- name: Validate increase requested
+  ansible.builtin.debug:
+    msg: "Nothing to do! Boot partition already equal to or greater than requested size."
+  when: bigboot_increase_bytes | int <= 0

--- a/roles/bigboot/templates/increase-boot-partition.sh.j2
+++ b/roles/bigboot/templates/increase-boot-partition.sh.j2
@@ -11,12 +11,12 @@ main() {
     start=$(/usr/bin/date +%s)
     activate_volume_groups
     # run bigboot.sh to increase boot partition and file system size
-    ret=$(sh /usr/bin/bigboot.sh -d="{{ bigboot_boot_device_name }}" -s="{{ bigboot_size }}" -b="{{ bigboot_boot_partition_number }}" -p="{{ bigboot_boot_device_partition_prefix }}" 2>/dev/kmsg)
+    ret=$(sh /usr/bin/bigboot.sh -d="{{ bigboot_boot_device_name }}" -s="{{ bigboot_increase_bytes }}" -b="{{ bigboot_boot_partition_number }}" -p="{{ bigboot_boot_device_partition_prefix }}" 2>/dev/kmsg)
     status=$?
     end=$(/usr/bin/date +%s)
     # write the log file
     if [[ $status -eq 0 ]]; then
-        echo "[$name] Boot partition {{ bigboot_boot_device_name }} successfully increased by {{ bigboot_size }} ("$((end-start))" seconds) " >/dev/kmsg
+        echo "[$name] Boot partition {{ bigboot_boot_device_name }} successfully increased by {{ bigboot_increase_bytes }} ("$((end-start))" seconds) " >/dev/kmsg
     else
         echo "[$name] Failed to extend boot partition: $ret ("$((end-start))" seconds)" >/dev/kmsg
     fi


### PR DESCRIPTION
This PR introduces the new bigboot_partition_size variable to make the bigboot role more idempotent. 

Fixes #69. 