### PR TITLE
Improve bigboot role when called in check mode

### DIFF
--- a/changelogs/fragments/78-improve-bigboot-check-mode.yml
+++ b/changelogs/fragments/78-improve-bigboot-check-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Support check mode when using the bigboot role

--- a/roles/bigboot/tasks/do_bigboot_reboot.yml
+++ b/roles/bigboot/tasks/do_bigboot_reboot.yml
@@ -46,3 +46,4 @@
       Boot filesystem size is now
       {{ bigboot_boot_fs_new_size | int | human_readable }}
       ({{ (bigboot_boot_fs_new_size | int - bigboot_boot_fs_original_size | int) | human_readable }} increase)
+  when: not ansible_check_mode

--- a/roles/bigboot/tasks/prep_lvm.yml
+++ b/roles/bigboot/tasks/prep_lvm.yml
@@ -17,7 +17,6 @@
   register: vg_extent_size
   check_mode: false
 
-
 - name: Align bigboot increase to extent size
   ansible.builtin.set_fact:
     bigboot_increase_bytes: "{{ bigboot_increase_bytes | int - (bigboot_increase_bytes | int % vg_extent_size.stdout | int) }}"

--- a/roles/bigboot/tasks/prep_lvm.yml
+++ b/roles/bigboot/tasks/prep_lvm.yml
@@ -15,6 +15,8 @@
       -o vg_extent_size {{ bigboot_next_partition_vg }}
   changed_when: false
   register: vg_extent_size
+  check_mode: false
+
 
 - name: Align bigboot increase to extent size
   ansible.builtin.set_fact:

--- a/roles/initramfs/tasks/preflight.yml
+++ b/roles/initramfs/tasks/preflight.yml
@@ -15,6 +15,7 @@
     cmd: /sbin/grubby --default-kernel
   register: initramfs_grubby_rc
   changed_when: false
+  check_mode: false
 
 - name: Parse default kernel version
   ansible.builtin.set_fact:


### PR DESCRIPTION
It would be nice to be able to use the bigboot role in check mode so that we can determine whether any changes would be made when it is called.

By default, calling the role in check mode fails with the following:

```
TASK [infra.lvm_snapshots.initramfs : Get default kernel] ******************************************************************************************************************************************************************************************************************
skipping: [client2.london.example.com]

TASK [infra.lvm_snapshots.initramfs : Parse default kernel version] ********************************************************************************************************************************************************************************************************
fatal: [client2.london.example.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: Unable to look up a name or access an attribute in template string ({{ ((((initramfs_grubby_rc.stdout_lines[0] | split('/'))[2] | split('-'))[1:]) | join('-')) | trim }}).\nMake sure your variable name does not contain invalid characters like '-': descriptor 'split' for 'str' objects doesn't apply to a 'AnsibleUndefined' object. descriptor 'split' for 'str' objects doesn't apply to a 'AnsibleUndefined' object. Unable to look up a name or access an attribute in template string ({{ ((((initramfs_grubby_rc.stdout_lines[0] | split('/'))[2] | split('-'))[1:]) | join('-')) | trim }}).\nMake sure your variable name does not contain invalid characters like '-': descriptor 'split' for 'str' objects doesn't apply to a 'AnsibleUndefined' object. descriptor 'split' for 'str' objects doesn't apply to a 'AnsibleUndefined' object\n\nThe error appears to be in '/home/richard/.ansible/collections/ansible_collections/infra/lvm_snapshots/roles/initramfs/tasks/preflight.yml': line 19, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Parse default kernel version\n  ^ here\n"}
```

To replicate this error, setup an inventory file with approriate access to a host and run:

`ansible all -m include_role -a "name=infra.lvm_snapshots.bigboot" -C`

When running in check mode, the "Get default kernel" [task](https://github.com/redhat-cop/infra.lvm_snapshots/blob/4fb8456dcc6100d2b11666e75918afde9725f7d1/roles/initramfs/tasks/preflight.yml#L13C1-L17C22) does not run.

The `ansible.builtin.command` could legitimately run commands that change the server so skipping them in check mode is a sensible default.

The pull request adds `check_mode: false` to those tasks which should be considered safe to run and adds a conditional check on the final validation task, since we expect this to fail if changes are not made.

<details>
<summary>Sample output when run in check mode and no changes are required: </summary>

```
PLAY [Apply bigboot role] ******************************************************

TASK [Gathering Facts] *********************************************************
ok: [client2.london.example.com]

TASK [bigboot : Make sure the required related facts are available] ************
ok: [client2.london.example.com]

TASK [Validate initramfs preflight] ********************************************

TASK [initramfs : Make sure the required related facts are available] **********
ok: [client2.london.example.com]

TASK [initramfs : Get kernel version] ******************************************
ok: [client2.london.example.com]

TASK [initramfs : Get default kernel] ******************************************
ok: [client2.london.example.com]

TASK [initramfs : Parse default kernel version] ********************************
ok: [client2.london.example.com]

TASK [initramfs : Check the values] ********************************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "Current kernel version 3.10.0-957.el7.x86_64 and default version 3.10.0-957.el7.x86_64 match"
}

TASK [bigboot : Get boot device info] ******************************************
included: /home/richard/ansible/infra.lvm_snapshots/roles/bigboot/tasks/get_boot_device_info.yml for client2.london.example.com

TASK [bigboot : Find the boot mount entry] *************************************
ok: [client2.london.example.com]

TASK [bigboot : Validate boot mount entry] *************************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Calculate the partition to look for] ***************************
ok: [client2.london.example.com]

TASK [bigboot : Find the boot device parent] ***********************************
ok: [client2.london.example.com] => (item={'key': 'vda', 'value': {'scheduler_mode': 'mq-deadline', 'rotational': '1', 'vendor': '0x1af4', 'sectors': '23068672', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': []}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {'vda1': {'sectorsize': 512, 'uuid': 'b752d1a1-b646-45aa-bbad-d68c4198d150', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': ['b752d1a1-b646-45aa-bbad-d68c4198d150']}, 'sectors': '1048576', 'start': '2048', 'holders': [], 'size': '512.00 MB'}, 'vda2': {'sectorsize': 512, 'uuid': None, 'links': {'masters': ['dm-0', 'dm-1'], 'labels': [], 'ids': ['lvm-pv-uuid-lSyzLD-uAcs-MYNU-JtKt-Avba-gbdH-Nr0NXt'], 'uuids': []}, 'sectors': '19920896', 'start': '1050624', 'holders': ['rhel-root', 'rhel-swap'], 'size': '9.50 GB'}}, 'holders': [], 'size': '11.00 GB'}})
skipping: [client2.london.example.com] => (item={'key': 'sr0', 'value': {'scheduler_mode': 'deadline', 'rotational': '1', 'vendor': 'QEMU', 'sectors': '8783872', 'links': {'masters': [], 'labels': ['RHEL-7.6\\x20Server.x86_64'], 'ids': ['ata-QEMU_DVD-ROM_QM00001'], 'uuids': ['2018-10-10-18-34-13-00']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '2048', 'removable': '1', 'support_discard': '0', 'model': 'QEMU DVD-ROM', 'partitions': {}, 'holders': [], 'size': '4.19 GB'}}) 
skipping: [client2.london.example.com] => (item={'key': 'dm-0', 'value': {'scheduler_mode': '', 'rotational': '1', 'vendor': None, 'sectors': '16769024', 'links': {'masters': [], 'labels': [], 'ids': ['dm-name-rhel-root', 'dm-uuid-LVM-ZwtymxDPb4R4TJPyNwddyQvoBO1k1vtY8sc2A1mtmNve5Ruk3csaiS5BeMbSlgP9'], 'uuids': ['9a06a6a8-f049-4417-a596-6dd32570a0b7']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {}, 'holders': [], 'size': '8.00 GB'}}) 
skipping: [client2.london.example.com] => (item={'key': 'dm-1', 'value': {'scheduler_mode': '', 'rotational': '1', 'vendor': None, 'sectors': '3137536', 'links': {'masters': [], 'labels': [], 'ids': ['dm-name-rhel-swap', 'dm-uuid-LVM-ZwtymxDPb4R4TJPyNwddyQvoBO1k1vtYleMllu3kQQaNkKKDLXo82YNe4JUR337k'], 'uuids': ['ce481133-43f0-45a1-9468-ff9f49d376b1']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {}, 'holders': [], 'size': '1.50 GB'}}) 

TASK [bigboot : Capture boot device details] ***********************************
ok: [client2.london.example.com]

TASK [bigboot : Calculate boot device current size] ****************************
ok: [client2.london.example.com]

TASK [bigboot : Find the next partition] ***************************************
ok: [client2.london.example.com] => (item=['vda1', {'sectorsize': 512, 'uuid': 'b752d1a1-b646-45aa-bbad-d68c4198d150', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': ['b752d1a1-b646-45aa-bbad-d68c4198d150']}, 'sectors': '1048576', 'start': '2048', 'holders': [], 'size': '512.00 MB'}])
skipping: [client2.london.example.com] => (item=['vda2', {'sectorsize': 512, 'uuid': None, 'links': {'masters': ['dm-0', 'dm-1'], 'labels': [], 'ids': ['lvm-pv-uuid-lSyzLD-uAcs-MYNU-JtKt-Avba-gbdH-Nr0NXt'], 'uuids': []}, 'sectors': '19920896', 'start': '1050624', 'holders': ['rhel-root', 'rhel-swap'], 'size': '9.50 GB'}]) 

TASK [bigboot : Validate next partition exists] ********************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Find Btrfs or LVM] *********************************************
ok: [client2.london.example.com]

TASK [bigboot : Validate next partition type] **********************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Convert bigboot_partition_size to bytes] ***********************
ok: [client2.london.example.com]

TASK [bigboot : Convert bigboot_size to bytes] *********************************
skipping: [client2.london.example.com]

TASK [bigboot : Calculate bigboot increase] ************************************
ok: [client2.london.example.com]

TASK [bigboot : Prepare Btrfs for bigboot] *************************************
skipping: [client2.london.example.com]

TASK [bigboot : Prepare LVM for bigboot] ***************************************
skipping: [client2.london.example.com]

TASK [bigboot : Configure pre-mount hook and reboot] ***************************
skipping: [client2.london.example.com]

TASK [bigboot : Validate increase requested] ***********************************
ok: [client2.london.example.com] => {
    "msg": "Nothing to do! Boot partition already equal to or greater than requested size."
}

PLAY RECAP *********************************************************************
client2.london.example.com : ok=21   changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
```
</details>


<details>
<summary>Sample output when run in check mode and changes are required:</summary>

```
PLAY [Apply bigboot role] ******************************************************

TASK [Gathering Facts] *********************************************************
ok: [client2.london.example.com]

TASK [bigboot : Make sure the required related facts are available] ************
ok: [client2.london.example.com]

TASK [Validate initramfs preflight] ********************************************

TASK [initramfs : Make sure the required related facts are available] **********
ok: [client2.london.example.com]

TASK [initramfs : Get kernel version] ******************************************
ok: [client2.london.example.com]

TASK [initramfs : Get default kernel] ******************************************
ok: [client2.london.example.com]

TASK [initramfs : Parse default kernel version] ********************************
ok: [client2.london.example.com]

TASK [initramfs : Check the values] ********************************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "Current kernel version 3.10.0-957.el7.x86_64 and default version 3.10.0-957.el7.x86_64 match"
}

TASK [bigboot : Get boot device info] ******************************************
included: /home/richard/ansible/infra.lvm_snapshots/roles/bigboot/tasks/get_boot_device_info.yml for client2.london.example.com

TASK [bigboot : Find the boot mount entry] *************************************
ok: [client2.london.example.com]

TASK [bigboot : Validate boot mount entry] *************************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Calculate the partition to look for] ***************************
ok: [client2.london.example.com]

TASK [bigboot : Find the boot device parent] ***********************************
ok: [client2.london.example.com] => (item={'key': 'vda', 'value': {'scheduler_mode': 'mq-deadline', 'rotational': '1', 'vendor': '0x1af4', 'sectors': '23068672', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': []}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {'vda1': {'sectorsize': 512, 'uuid': 'b752d1a1-b646-45aa-bbad-d68c4198d150', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': ['b752d1a1-b646-45aa-bbad-d68c4198d150']}, 'sectors': '1048576', 'start': '2048', 'holders': [], 'size': '512.00 MB'}, 'vda2': {'sectorsize': 512, 'uuid': None, 'links': {'masters': ['dm-0', 'dm-1'], 'labels': [], 'ids': ['lvm-pv-uuid-lSyzLD-uAcs-MYNU-JtKt-Avba-gbdH-Nr0NXt'], 'uuids': []}, 'sectors': '19920896', 'start': '1050624', 'holders': ['rhel-root', 'rhel-swap'], 'size': '9.50 GB'}}, 'holders': [], 'size': '11.00 GB'}})
skipping: [client2.london.example.com] => (item={'key': 'sr0', 'value': {'scheduler_mode': 'deadline', 'rotational': '1', 'vendor': 'QEMU', 'sectors': '8783872', 'links': {'masters': [], 'labels': ['RHEL-7.6\\x20Server.x86_64'], 'ids': ['ata-QEMU_DVD-ROM_QM00001'], 'uuids': ['2018-10-10-18-34-13-00']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '2048', 'removable': '1', 'support_discard': '0', 'model': 'QEMU DVD-ROM', 'partitions': {}, 'holders': [], 'size': '4.19 GB'}}) 
skipping: [client2.london.example.com] => (item={'key': 'dm-0', 'value': {'scheduler_mode': '', 'rotational': '1', 'vendor': None, 'sectors': '16769024', 'links': {'masters': [], 'labels': [], 'ids': ['dm-name-rhel-root', 'dm-uuid-LVM-ZwtymxDPb4R4TJPyNwddyQvoBO1k1vtY8sc2A1mtmNve5Ruk3csaiS5BeMbSlgP9'], 'uuids': ['9a06a6a8-f049-4417-a596-6dd32570a0b7']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {}, 'holders': [], 'size': '8.00 GB'}}) 
skipping: [client2.london.example.com] => (item={'key': 'dm-1', 'value': {'scheduler_mode': '', 'rotational': '1', 'vendor': None, 'sectors': '3137536', 'links': {'masters': [], 'labels': [], 'ids': ['dm-name-rhel-swap', 'dm-uuid-LVM-ZwtymxDPb4R4TJPyNwddyQvoBO1k1vtYleMllu3kQQaNkKKDLXo82YNe4JUR337k'], 'uuids': ['ce481133-43f0-45a1-9468-ff9f49d376b1']}, 'sas_device_handle': None, 'sas_address': None, 'virtual': 1, 'host': '', 'sectorsize': '512', 'removable': '0', 'support_discard': '0', 'model': None, 'partitions': {}, 'holders': [], 'size': '1.50 GB'}}) 

TASK [bigboot : Capture boot device details] ***********************************
ok: [client2.london.example.com]

TASK [bigboot : Calculate boot device current size] ****************************
ok: [client2.london.example.com]

TASK [bigboot : Find the next partition] ***************************************
ok: [client2.london.example.com] => (item=['vda1', {'sectorsize': 512, 'uuid': 'b752d1a1-b646-45aa-bbad-d68c4198d150', 'links': {'masters': [], 'labels': [], 'ids': [], 'uuids': ['b752d1a1-b646-45aa-bbad-d68c4198d150']}, 'sectors': '1048576', 'start': '2048', 'holders': [], 'size': '512.00 MB'}])
skipping: [client2.london.example.com] => (item=['vda2', {'sectorsize': 512, 'uuid': None, 'links': {'masters': ['dm-0', 'dm-1'], 'labels': [], 'ids': ['lvm-pv-uuid-lSyzLD-uAcs-MYNU-JtKt-Avba-gbdH-Nr0NXt'], 'uuids': []}, 'sectors': '19920896', 'start': '1050624', 'holders': ['rhel-root', 'rhel-swap'], 'size': '9.50 GB'}]) 

TASK [bigboot : Validate next partition exists] ********************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Find Btrfs or LVM] *********************************************
ok: [client2.london.example.com]

TASK [bigboot : Validate next partition type] **********************************
ok: [client2.london.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigboot : Convert bigboot_partition_size to bytes] ***********************
ok: [client2.london.example.com]

TASK [bigboot : Convert bigboot_size to bytes] *********************************
skipping: [client2.london.example.com]

TASK [bigboot : Calculate bigboot increase] ************************************
ok: [client2.london.example.com]

TASK [bigboot : Prepare Btrfs for bigboot] *************************************
skipping: [client2.london.example.com]

TASK [bigboot : Prepare LVM for bigboot] ***************************************
included: /home/richard/ansible/infra.lvm_snapshots/roles/bigboot/tasks/prep_lvm.yml for client2.london.example.com

TASK [bigboot : Find physical volume size] *************************************
skipping: [client2.london.example.com]

TASK [bigboot : Find volume group extent size] *********************************
ok: [client2.london.example.com]

TASK [bigboot : Align bigboot increase to extent size] *************************
ok: [client2.london.example.com]

TASK [bigboot : Test mode pvresize] ********************************************
skipping: [client2.london.example.com]

TASK [bigboot : Evict extents from end of physical volume] *********************
skipping: [client2.london.example.com]

TASK [bigboot : Real pvresize] *************************************************
skipping: [client2.london.example.com]

TASK [bigboot : Configure pre-mount hook and reboot] ***************************
included: /home/richard/ansible/infra.lvm_snapshots/roles/bigboot/tasks/do_bigboot_reboot.yml for client2.london.example.com

TASK [bigboot : Copy dracut pre-mount hook files] ******************************
changed: [client2.london.example.com] => (item=bigboot.sh)
changed: [client2.london.example.com] => (item=module-setup.sh)
changed: [client2.london.example.com] => (item=sfdisk.static)

TASK [bigboot : Resolve and copy pre-mount hook wrapper script] ****************
changed: [client2.london.example.com]

TASK [Create the initramfs and reboot to run the module] ***********************

TASK [initramfs : Make sure the required related facts are available] **********
ok: [client2.london.example.com]

TASK [initramfs : Get kernel version] ******************************************
ok: [client2.london.example.com]

TASK [initramfs : Create a backup of the current initramfs] ********************
changed: [client2.london.example.com]

TASK [initramfs : Create a new initramfs with the optional additional modules] ***
skipping: [client2.london.example.com]

TASK [initramfs : Reboot the server] *******************************************
changed: [client2.london.example.com]

TASK [initramfs : Restore previous initramfs] **********************************
skipping: [client2.london.example.com]

TASK [bigboot : Remove dracut extend boot module] ******************************
ok: [client2.london.example.com]

TASK [bigboot : Retrieve mount points] *****************************************
ok: [client2.london.example.com]

TASK [bigboot : Capture boot filesystem new size] ******************************
ok: [client2.london.example.com]

TASK [bigboot : Validate boot filesystem new size] *****************************
skipping: [client2.london.example.com]

TASK [bigboot : Validate increase requested] ***********************************
skipping: [client2.london.example.com]

PLAY RECAP *********************************************************************
client2.london.example.com : ok=33   changed=4    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0   
```
</details>
