### PR TITLE
Prevent snapshot creation if newest installed kernel not in use

### DIFF
--- a/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
+++ b/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Prevent snapshot creation when newest installed kernel is not in use

--- a/roles/snapshot_create/tasks/check.yml
+++ b/roles/snapshot_create/tasks/check.yml
@@ -1,3 +1,9 @@
+- name: Validate default kernel is booted
+  ansible.builtin.include_role:
+    name: initramfs
+    tasks_from: preflight
+  when: snapshot_create_boot_backup
+
 - name: Verify that all volumes exist
   ansible.builtin.include_tasks: verify_volume_exists.yml
   loop: "{{ snapshot_create_volumes }}"


### PR DESCRIPTION
Resolves https://github.com/redhat-cop/infra.lvm_snapshots/issues/84