### PR TITLE
Bind/Overlay device fix

### DIFF
--- a/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
+++ b/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- Prevent snapshot creation when newest installed kernel is not in use

--- a/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
+++ b/changelogs/fragments/84-prevent-snapshot-if-newest-installed-kernel-not-in-use.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Prevent snapshot creation when newest installed kernel is not in use

--- a/changelogs/fragments/87-check-device-fix.yml
+++ b/changelogs/fragments/87-check-device-fix.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- Updates to support hosts with bind/overlay mounts attached
+  to the device intended to be operated on.

--- a/roles/shrink_lv/tasks/check_device.yaml
+++ b/roles/shrink_lv/tasks/check_device.yaml
@@ -4,7 +4,7 @@
 
 - name: Assert that the mount point exists
   ansible.builtin.assert:
-    that: (shrink_lv_mount_info | length) == 1
+    that: (shrink_lv_mount_info | length) >= 1
     fail_msg: "Mount point {{ item.device }} does not exist"
 
 - name: Assert that the filesystem is supported

--- a/roles/shrink_lv/tasks/check_device.yaml
+++ b/roles/shrink_lv/tasks/check_device.yaml
@@ -1,20 +1,20 @@
 - name: Get the mount point info
   ansible.builtin.set_fact:
-    shrink_lv_mount_info: "{{ ansible_facts.mounts | selectattr('device', 'equalto', item.device) }}"
+    shrink_lv_mount_info: "{{ ansible_facts['mounts'] | selectattr('device', 'equalto', item['device']) | first }}"
 
 - name: Assert that the mount point exists
   ansible.builtin.assert:
-    that: (shrink_lv_mount_info | length) >= 1
-    fail_msg: "Mount point {{ item.device }} does not exist"
+    that: shrink_lv_mount_info['device'] is defined
+    fail_msg: "Mount point {{ item['device'] }} does not exist"
 
 - name: Assert that the filesystem is supported
   ansible.builtin.assert:
-    that: shrink_lv_mount_info[0].fstype in ['ext4']
-    fail_msg: "Unsupported filesystem '{{ shrink_lv_mount_info[0].fstype }}' on '{{ item.device }}'"
+    that: shrink_lv_mount_info['fstype'] in ['ext4']
+    fail_msg: "Unsupported filesystem '{{ shrink_lv_mount_info['fstype'] }}' on '{{ item['device'] }}'"
 
 - name: Assert that the filesystem has enough free space
   ansible.builtin.assert:
-    that: shrink_lv_mount_info[0].block_size * shrink_lv_mount_info[0].block_used < (item.size | ansible.builtin.human_to_bytes)
+    that: shrink_lv_mount_info['block_size'] * shrink_lv_mount_info['block_used'] < (item['size'] | ansible.builtin.human_to_bytes)
     fail_msg: >
-      Requested size {{ item.size }} is smaller than currently used
-      {{ (shrink_lv_mount_info[0].block_size * shrink_lv_mount_info[0].block_used) | ansible.builtin.human_readable }}
+      Requested size {{ item['size'] }} is smaller than currently used
+      {{ (shrink_lv_mount_info['block_size'] * shrink_lv_mount_info['block_used']) | ansible.builtin.human_readable }}

--- a/roles/shrink_lv/tasks/check_if_shrunk.yml
+++ b/roles/shrink_lv/tasks/check_if_shrunk.yml
@@ -1,0 +1,13 @@
+---
+- name: Set device for mount
+  ansible.builtin.set_fact:
+    shrink_lv_set_device: "{{ ansible_facts['mounts'] | selectattr('device', 'equalto', item['device']) | first }}"
+
+- name: Assert that the filesystem has shrunk
+  ansible.builtin.assert:
+    # yamllint disable-line rule:line-length
+    that: (shrink_lv_set_device['size_total'] | int) <= (item['size'] | ansible.builtin.human_to_bytes)
+    fail_msg: >
+      Logical Volume {{ item['device'] }} was NOT shrunk as requested.
+    success_msg: >
+      Logical Volume {{ item['device'] }} has been shrunk as requested.

--- a/roles/shrink_lv/tasks/check_if_shrunk.yml
+++ b/roles/shrink_lv/tasks/check_if_shrunk.yml
@@ -5,7 +5,6 @@
 
 - name: Assert that the filesystem has shrunk
   ansible.builtin.assert:
-    # yamllint disable-line rule:line-length
     that: (shrink_lv_set_device['size_total'] | int) <= (item['size'] | ansible.builtin.human_to_bytes)
     fail_msg: >
       Logical Volume {{ item['device'] }} was NOT shrunk as requested.

--- a/roles/shrink_lv/tasks/main.yaml
+++ b/roles/shrink_lv/tasks/main.yaml
@@ -43,12 +43,6 @@
     - "!min"
     - mounts
 
-- name: Assert that the filesystem has shrunk
-  ansible.builtin.assert:
-    # yamllint disable-line rule:line-length
-    that: (ansible_facts.mounts | selectattr('device', 'equalto', item.device) | map(attribute='size_total') | join | int) <= (item.size | ansible.builtin.human_to_bytes)
-    fail_msg: >
-      Logical Volume {{ item.device }} was not shrunk to {{ item.size }} as requested
-    success_msg: >
-      Logical Volume {{ item.device }} has been shrunk to {{ item.size }} as requested.
+- name: Check if device has shrunken successfully
+  ansible.builtin.include_tasks: check_if_shrunk.yml
   loop: "{{ shrink_lv_devices }}"


### PR DESCRIPTION
For hosts running services such as `Docker` or `named-chroot`, bind/overlay mounts
are created under an existing device node. This has the result reporting multiple
results for the mount point existence assertion, which ultimately causes a
failure due to accepting only a single result.

This set of updates changes the logic to support these hosts.

Below are outputs from the `mount` command and `ansible_facts['mounts']`
from an example host running both of these services.

Output from `mount`:
```
/dev/mapper/system-root on / type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/localtime type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/named.root.key type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/named.conf type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/named.rfc1912.zones type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/rndc.key type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/named.iscdlv.key type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/protocols type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/services type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/etc/named type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/usr/lib64/bind type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/named/chroot/var/named type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/lib/docker/containers type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/system-root on /var/lib/docker/overlay2 type ext4 (rw,relatime,seclabel,data=ordered)
```

Truncated example output from `ansible_facts['mounts']`:
```
        {
            "block_available": 16410821,
            "block_size": 4096,
            "block_total": 18245904,
            "block_used": 1835083,
            "device": "/dev/mapper/system-root",
            "fstype": "ext4",
            "inode_available": 4582572,
            "inode_total": 4644864,
            "inode_used": 62292,
            "mount": "/",
            "options": "rw,seclabel,relatime,data=ordered",
            "size_available": 67218722816,
            "size_total": 74735222784,
            "uuid": "588943e8-02c5-429b-a8d4-1b6ff390b051"
        },
        {
            "block_available": 16410821,
            "block_size": 4096,
            "block_total": 18245904,
            "block_used": 1835083,
            "device": "/dev/mapper/system-root",
            "fstype": "ext4",
            "inode_available": 4582572,
            "inode_total": 4644864,
            "inode_used": 62292,
            "mount": "/var/lib/docker/overlay2",
            "options": "rw,seclabel,relatime,data=ordered,bind",
            "size_available": 67218722816,
            "size_total": 74735222784,
            "uuid": "588943e8-02c5-429b-a8d4-1b6ff390b051"
        },
        {
            "block_available": 16410821,
            "block_size": 4096,
            "block_total": 18245904,
            "block_used": 1835083,
            "device": "/dev/mapper/system-root",
            "fstype": "ext4",
            "inode_available": 4582572,
            "inode_total": 4644864,
            "inode_used": 62292,
            "mount": "/var/named/chroot/var/named",
            "options": "rw,seclabel,relatime,data=ordered,bind",
            "size_available": 67218722816,
            "size_total": 74735222784,
            "uuid": "588943e8-02c5-429b-a8d4-1b6ff390b051"
        },
```