### PR TITLE
add galaxy import checker

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -16,3 +16,17 @@ jobs:
 
     - name: Run ansible-lint
       uses: ansible/ansible-lint@main
+  build-import:
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
+  all_green:
+    if: ${{ always() }}
+    needs:
+      - ansible-lint
+      - build-import
+    runs-on: ubuntu-latest
+    steps:
+      - run: >-
+          python -c "assert set([
+          '${{ needs.ansible-lint.result }}',
+          '${{ needs.build-import.result }}',
+          ]) == {'success'}"


### PR DESCRIPTION
Adds build import to the github PR workflow, this will enable you to see errors before they happen for console.redhat.com publishing. It runs the same code it runs to validate the collection.