### PR TITLE
Update drain check for thin LVs

### DIFF
--- a/changelogs/fragments/thin-pool-drain.yml
+++ b/changelogs/fragments/thin-pool-drain.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Update snapshot drain check when LVM thin pools are used

--- a/changelogs/fragments/thin-pool-drain.yml
+++ b/changelogs/fragments/thin-pool-drain.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - Update snapshot drain check when LVM thin pools are used
+  - Update active snapshot check for LVM thin pool case

--- a/changelogs/fragments/thin-pool-drain.yml
+++ b/changelogs/fragments/thin-pool-drain.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - Update snapshot drain check when LVM thin pools are used
   - Update active snapshot check for LVM thin pool case
+  - Update snapshot creation when using LVM thin provisioned volume

--- a/roles/snapshot_create/tasks/create.yml
+++ b/roles/snapshot_create/tasks/create.yml
@@ -38,7 +38,7 @@
     vg: "{{ item.vg }}"
     lv: "{{ item.lv }}"
     snapshot: "{{ item.lv }}_{{ snapshot_create_set_name }}"
-    size: "{{ item.size | default(omit) }}"
+    size: "{{ (item.size == '0.0B') | ternary(omit, item.size) }}"
   loop: "{{ snapshot_create_volumes }}"
 
 - name: Required packages are present

--- a/roles/snapshot_revert/tasks/main.yml
+++ b/roles/snapshot_revert/tasks/main.yml
@@ -68,7 +68,7 @@
   register: snapshot_revert_lv_drain_check
   until: >-
     (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].data_percent == "" or
-    (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].lv_attr == "Vwi-aotz--"
+    (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].lv_attr[0] == "V"
   retries: 20
   delay: 30
   loop: "{{ snapshot_revert_snapshots }}"

--- a/roles/snapshot_revert/tasks/main.yml
+++ b/roles/snapshot_revert/tasks/main.yml
@@ -66,7 +66,9 @@
 - name: Wait for the snapshot to drain
   ansible.builtin.command: "lvs --select 'vg_name = {{ item.vg_name }} && lv_name = {{ item.origin }}' --reportformat json"
   register: snapshot_revert_lv_drain_check
-  until: (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].data_percent == ""
+  until: >-
+    (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].data_percent == "" or
+    (snapshot_revert_lv_drain_check.stdout | from_json).report[0].lv[0].lv_attr == "Vwi-aotz--"
   retries: 20
   delay: 30
   loop: "{{ snapshot_revert_snapshots }}"

--- a/roles/snapshot_revert/tasks/verify_snapshot_active.yml
+++ b/roles/snapshot_revert/tasks/verify_snapshot_active.yml
@@ -10,5 +10,5 @@
 - name: Verify that the snapshot is active
   ansible.builtin.assert:
     that:
-    - snapshot_revert_lv_attr[0] == 's'
+    - snapshot_revert_lv_attr[0] == 's' or snapshot_revert_lv_attr[0] == 'V'
     - snapshot_revert_lv_attr[4] == 'a'

--- a/roles/snapshot_revert/tasks/verify_snapshot_active.yml
+++ b/roles/snapshot_revert/tasks/verify_snapshot_active.yml
@@ -10,5 +10,4 @@
 - name: Verify that the snapshot is active
   ansible.builtin.assert:
     that:
-    - snapshot_revert_lv_attr[0] == 's' or snapshot_revert_lv_attr[0] == 'V'
-    - snapshot_revert_lv_attr[4] == 'a'
+    - (snapshot_revert_lv_attr[0] == 's' and snapshot_revert_lv_attr[4] == 'a') or snapshot_revert_lv_attr[0] == 'V'


### PR DESCRIPTION
Potential fix for https://github.com/redhat-cop/infra.lvm_snapshots/issues/77

When thin volumes are in use and the `snapshot_create` role is invoked, the logical volumes are similar to this:

```[root@rhel8a testvol]# lvs
  LV              VG     Attr       LSize   Pool       Origin     Data%  Meta%  Move Log Cpy%Sync Convert
  mythinpool      testvg twi-aotz-- 100.00m                       10.69  10.94                           
  thinvolume      testvg owi-aotz--   1.00g mythinpool            1.04                                   
  thinvolume_ripu testvg swi-a-s---  52.00m            thinvolume 0.14                                   
```

When the snapshots are reverted and drained, the logical volumes are set as follows:

```
[root@rhel8a ~]# lvs
  LV         VG     Attr       LSize   Pool       Origin Data%  Meta%  Move Log Cpy%Sync Convert
  mythinpool testvg twi-aotz-- 100.00m                   11.38  10.94                           
  thinvolume testvg Vwi-aotz--   1.00g mythinpool        1.11                                   
```

Note that unlike with the thick LVM volumes, 'data' is not set to a zero value.

This change updates the drain check so that it looks for either a zero data value (thick LVM case) or the attributes `Vwi-aotz--` in the thin LVM case.

`Vwi-aotz--`should be the case where a volume has been actively used for a snapshot and then rolled back.

The `lv_attr` bits in the above are:

       1  Volume type: thin (V)olume

       2  Permissions: (w)riteable

       3  Allocation policy:  (i)nherited

       4  fixed (m)inor: UNSET

       5  State: (a)ctive
       
       6  device (o)pen

       7  Target type: (t)hin

       8  Newly-allocated data blocks are overwritten with blocks of (z)eroes

       9  Volume Health, where there are currently three groups of attributes identified: UNSET

       10 s(k)ip activation: this volume is flagged to be skipped during activation: UNSET
       
An alternative might be to just check for the first lv_attr bit and note when it has changed from`O` (Origin with merging snapshot) to `V`(Thin Volume) on rollback.