### PR TITLE
workflow can no longer upload builds to the now immutable tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,12 +135,4 @@ jobs:
 
       - name: Publish to galaxy
         run: ansible-galaxy collection publish --api-key=${{ secrets.GALAXY_INFRA_KEY }} ${{ steps.build.outputs.tar_file }}
-
-      - name: Upload files to tag
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.build.outputs.tar_file }}
-          tag: ${{ github.ref }}
-          overwrite: true
 ...

--- a/changelogs/fragments/no_upload_build_to_gitgub.yml
+++ b/changelogs/fragments/no_upload_build_to_gitgub.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Release workflow can no longer upload builds to the now immutable tags


### PR DESCRIPTION
Removing the last step of the release workflow that used to add the build tarball to the assets listed on the GitHub release page. This is no longer possible because of GitHub enabling immutable tags (see [here](https://github.com/redhat-cop/infra.lvm_snapshots/actions/runs/29859131556/job/88731390143#step:12:17)).

This is a "good thing" (tm) from a secure software supply chain perspective. To the extent that you can trust Galaxy or Red Hat AH, feel safe pulling the collection from those. If you wear a tin foil hat, pull the source using the immutable tag and build using your own secure pipeline. 